### PR TITLE
Fixing WEIRD dependency specification

### DIFF
--- a/dragonfly-fog_data_store.gemspec
+++ b/dragonfly-fog_data_store.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_runtime_dependency "dragonfly", "~> 1.0"
-  spec.add_runtime_dependency "fog", '~> 0'
+  spec.add_runtime_dependency "fog", '~> 1.28.0'
   spec.add_development_dependency "rspec", "~> 2.0"
 end

--- a/lib/dragonfly/fog_data_store/version.rb
+++ b/lib/dragonfly/fog_data_store/version.rb
@@ -1,5 +1,5 @@
 module Dragonfly
   class FogDataStore
-    VERSION = "0.0.1"
+    VERSION = "0.0.2"
   end
 end


### PR DESCRIPTION
1.28.0 is what I need elsewhere. ~> 0 was grabbing some old garbage version.
